### PR TITLE
fix/Markdown-title-format

### DIFF
--- a/docs/developer/retrosharemobile.md
+++ b/docs/developer/retrosharemobile.md
@@ -123,7 +123,7 @@ You may filter the content of trace.txt than by "restroshare" to get only the li
 TBD; actual not knwon how to setup a debug-environment fort it.  
 Hints in context: https://gitlab.com/elRepo.io/elRepo.io-android/-/issues/43
 
-##Tracing RetroShare-Service in the context of the android-activities
+## Tracing RetroShare-Service in the context of the android-activities
 As above with the adb.exe tool.
 If you want manually check the communication interface of the service 
 you may use the cUrl tool.


### PR DESCRIPTION
(cherry picked from commit af2f04b3cc34e6d6f8c65f343a7cae3bf326da82)
of: https://github.com/obrasero/retroshare-mobile